### PR TITLE
docker-compose keyCloak service delete

### DIFF
--- a/boot/office/docker-compose.yml
+++ b/boot/office/docker-compose.yml
@@ -1,27 +1,6 @@
 version: "3.9"
 
 services:
-  keycloak:
-    image: quay.io/keycloak/keycloak:26.2.5
-    command:
-      - start
-      - --http-enabled=true
-      - --http-port=8080
-      - --hostname=ec2-43-203-109-89.ap-northeast-2.compute.amazonaws.com
-
-    environment:
-      KC_DB: ${KC_DB}
-      KC_DB_URL: ${URL}
-      KC_DB_USERNAME: ${USERNAME}
-      KC_DB_PASSWORD: ${PASSWORD}
-      KC_HOSTNAME_STRICT: false
-      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
-      KC_PROXY: edge
-    ports:
-      - "9001:8080"
-    networks:
-      - office
 
   office-api-server:
     image: ${OFFICE_API_IMAGE_URI}


### PR DESCRIPTION
키클록 연동 제거를 위해 도커 컴포즈의 서비스에서 키클록을 삭제함